### PR TITLE
move banner and pictures html to snippets

### DIFF
--- a/datacatalog.html
+++ b/datacatalog.html
@@ -11,6 +11,8 @@
             crossorigin="anonymous"></script>
     <script src="/js/load_menu.js"></script>
     <script src="/js/load_footer.js"></script>
+    <script src="/js/load_banner.js"></script>
+    <script src="/js/load_pictures.js"></script>
 
     <meta charset="UTF-8">
     <title>Title</title>
@@ -20,41 +22,9 @@
 <div id="menu"></div>
 <!-- end menu-->
 
-
-<div class="row"> <!-- Title banner row -->
-
-    <div col-12 col-md-6>
-
-
-        <div class="col-12 d-none d-lg-block">
-            <svg class="bd-placeholder-img" width="100%" height="500" xmlns="http://www.w3.org/2000/svg" role="img"
-                 aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
-                <title>Placeholder</title>
-
-                <rect width="100%" height="100%" fill="#55595c"/>
-                <text x="50%" y="50%" fill="#eceeef" dy=".3em">Background Image</text>
-                <text x="20%" y="50%" fill="#eceeef" dy=".3em">Slogan</text>
-                <text x="20%" y="60%" fill="#eceeef" dy=".3em">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                </text>
-                <text x="20%" y="65%" fill="#eceeef" dy=".3em">
-                    Ut libero nisl, suscipit sit amet sem vitae, feugiat imperdiet tortor.
-                </text>
-                <text x="20%" y="70%" fill="#eceeef" dy=".3em">
-                    Duis vitae bibendum magna. Vestibulum a dui id nunc
-                </text>
-                <text x="20%" y="75%" fill="#eceeef" dy=".3em">
-                    Proin nisi dui, pretium non accumsan quis, hendrerit eget orci.
-                    Sed ornare purus malesuada, vestibulum libero placerat, bibendum tortor.
-                </text>
-                <text x="20%" y="80%" fill="#eceeef" dy=".3em">
-                    Etiam ut massa est. Aenean lorem magna, consequat in egestas et, fringilla sit amet mi.
-                </text>
-            </svg>
-        </div>
-    </div>
-</div> <!-- End title banner row-->
-
+<!-- Include banner -->
+<div id="banner"></div>
+<!-- end banner -->
 
 <div class="row pt-5"> <!-- Page title  -->
     <div class="col-4"></div>
@@ -211,87 +181,9 @@
 <div id="accordionContentDisplay"></div>
 <!-- End dynamic node registry content -->
 
-
-<!-- Start pictures section row-->
-<div class="row d-none d-sm-block  ">
-    <div class="album  py-5 bg-body-tertiary ">
-        <div class="  container  ">
-            <div class="row  row-cols-1 row-cols-sm-2 row-cols-md-3 g-3   ">
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-eVcfzGhVpYc-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-EpTN7eW3OZs-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-rXj2M7xtdB8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-7xF_CS4JC8c-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-xnrDoc_Hmm8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-</div>
-<!-- End  pictures section row-->
-
+<!-- Include pictures -->
+<div id="pictures"></div>
+<!-- end pictures -->
 
 <!-- Start footer -->
 <div class="row">

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 
     <script src="/js/load_menu.js"></script>
     <script src="/js/load_footer.js"></script>
+    <script src="/js/load_banner.js"></script>
+    <script src="/js/load_pictures.js"></script>
     <meta charset="UTF-8">
 
     <title>Title</title>
@@ -20,60 +22,11 @@
 
 <!-- Include menu -->
 <div id="menu"></div>
-
 <!-- end menu-->
 
-
-<div class="row"> <!-- Title banner row -->
-
-    <div col-12 col-md-6>
-
-
-        <div class="col-12 d-none d-lg-block">
-            <svg class="bd-placeholder-img" width="100%" height="500" xmlns="http://www.w3.org/2000/svg" role="img"
-                 aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
-                <title>Placeholder</title>
-
-                <rect width="100%" height="100%" fill="#55595c"/>
-                <text x="50%" y="50%" fill="#eceeef" dy=".3em">Background Image</text>
-
-
-                <text x="20%" y="50%" fill="#eceeef" dy=".3em">Slogan</text>
-                <text x="20%" y="60%" fill="#eceeef" dy=".3em">
-
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                </text>
-                <text x="20%" y="65%" fill="#eceeef" dy=".3em">
-
-                    Ut libero nisl, suscipit sit amet sem vitae, feugiat imperdiet tortor.
-
-                </text>
-
-                <text x="20%" y="70%" fill="#eceeef" dy=".3em">
-
-
-                    Duis vitae bibendum magna. Vestibulum a dui id nunc
-
-                </text>
-                <text x="20%" y="75%" fill="#eceeef" dy=".3em">
-
-                    Proin nisi dui, pretium non accumsan quis, hendrerit eget orci.
-                    Sed ornare purus malesuada, vestibulum libero placerat, bibendum tortor.
-                </text>
-                <text x="20%" y="80%" fill="#eceeef" dy=".3em">
-                    Etiam ut massa est. Aenean lorem magna, consequat in egestas et, fringilla sit amet mi.
-
-                </text>
-
-                <!---->
-
-            </svg>
-        </div>
-
-    </div>
-
-</div> <!-- End title banner row-->
-
+<!-- Include banner -->
+<div id="banner"></div>
+<!-- end banner -->
 
 <div class="row pt-5"> <!-- Page title -->
     <div class="col-4"></div>
@@ -195,92 +148,9 @@
     </div>
 </div><!-- End Learn About DACCS content section -->
 
-
-<div class="row d-none d-sm-block  "> <!-- Start pictures section row-->
-    <div class="album  py-5 bg-body-tertiary ">
-        <div class="container">
-
-            <div class="row  row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-eVcfzGhVpYc-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-EpTN7eW3OZs-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-rXj2M7xtdB8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-7xF_CS4JC8c-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-xnrDoc_Hmm8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-    </div>
-</div> <!-- End  pictures section row-->
-
+<!-- Include pictures -->
+<div id="pictures"></div>
+<!-- end pictures -->
 
 <div class="row">
     <div class="container">

--- a/js/load_banner.js
+++ b/js/load_banner.js
@@ -1,0 +1,8 @@
+document.addEventListener("DOMContentLoaded", function () {
+    fetch("/snippets/banner.html").then(resp => resp.text()).then(banner_html => {
+        const banner = document.getElementById("banner");
+        const template = document.createElement("template");
+        template.innerHTML = banner_html;
+        banner.appendChild(template.content)
+    })
+});

--- a/js/load_pictures.js
+++ b/js/load_pictures.js
@@ -1,0 +1,8 @@
+document.addEventListener("DOMContentLoaded", function () {
+    fetch("/snippets/pictures.html").then(resp => resp.text()).then(pictures_html => {
+        const pictures = document.getElementById("pictures");
+        const template = document.createElement("template");
+        template.innerHTML = pictures_html;
+        pictures.appendChild(template.content)
+    })
+});

--- a/snippets/banner.html
+++ b/snippets/banner.html
@@ -1,0 +1,49 @@
+<div class="row"> <!-- Title banner row -->
+
+    <div col-12 col-md-6>
+
+
+        <div class="col-12 d-none d-lg-block">
+            <svg class="bd-placeholder-img" width="100%" height="500" xmlns="http://www.w3.org/2000/svg" role="img"
+                 aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
+                <title>Placeholder</title>
+
+                <rect width="100%" height="100%" fill="#55595c"/>
+                <text x="50%" y="50%" fill="#eceeef" dy=".3em">Background Image</text>
+
+
+                <text x="20%" y="50%" fill="#eceeef" dy=".3em">Slogan</text>
+                <text x="20%" y="60%" fill="#eceeef" dy=".3em">
+
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                </text>
+                <text x="20%" y="65%" fill="#eceeef" dy=".3em">
+
+                    Ut libero nisl, suscipit sit amet sem vitae, feugiat imperdiet tortor.
+
+                </text>
+
+                <text x="20%" y="70%" fill="#eceeef" dy=".3em">
+
+
+                    Duis vitae bibendum magna. Vestibulum a dui id nunc
+
+                </text>
+                <text x="20%" y="75%" fill="#eceeef" dy=".3em">
+
+                    Proin nisi dui, pretium non accumsan quis, hendrerit eget orci.
+                    Sed ornare purus malesuada, vestibulum libero placerat, bibendum tortor.
+                </text>
+                <text x="20%" y="80%" fill="#eceeef" dy=".3em">
+                    Etiam ut massa est. Aenean lorem magna, consequat in egestas et, fringilla sit amet mi.
+
+                </text>
+
+                <!---->
+
+            </svg>
+        </div>
+
+    </div>
+
+</div> <!-- End title banner row-->

--- a/snippets/pictures.html
+++ b/snippets/pictures.html
@@ -1,0 +1,84 @@
+<div class="row d-none d-sm-block  "> <!-- Start pictures section row-->
+    <div class="album  py-5 bg-body-tertiary ">
+        <div class="container">
+
+            <div class="row  row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <img src="images/usgs-eVcfzGhVpYc-unsplash.jpg" width="100%" height="225"/>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <img src="images/usgs-EpTN7eW3OZs-unsplash.jpg" width="100%" height="225"/>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <img src="images/usgs-rXj2M7xtdB8-unsplash.jpg" width="100%" height="225"/>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <img src="images/usgs-7xF_CS4JC8c-unsplash.jpg" width="100%" height="225"/>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <img src="images/usgs-xnrDoc_Hmm8-unsplash.jpg" width="100%" height="225"/>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
+                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
+                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
+                            <rect width="100%" height="100%" fill="#55595c"/>
+                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
+                        </svg>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
+                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
+                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
+                            <rect width="100%" height="100%" fill="#55595c"/>
+                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
+                        </svg>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
+                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
+                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
+                            <rect width="100%" height="100%" fill="#55595c"/>
+                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
+                        </svg>
+                    </div>
+                </div>
+
+                <div class="col">
+                    <div class="card shadow-sm">
+                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
+                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
+                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
+                            <rect width="100%" height="100%" fill="#55595c"/>
+                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
+                        </svg>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div> <!-- End  pictures section row-->

--- a/thredds.html
+++ b/thredds.html
@@ -11,6 +11,8 @@
     <link href="/css/daccs-css.css" rel="stylesheet">
     <script src="/js/load_menu.js"></script>
     <script src="/js/load_footer.js"></script>
+    <script src="/js/load_banner.js"></script>
+    <script src="/js/load_pictures.js"></script>
     <meta charset="UTF-8">
 
     <title>Title</title>
@@ -22,53 +24,9 @@
 <div id="menu"></div>
 <!-- end menu-->
 
-
-<div class="row"> <!-- Title banner row -->
-
-    <div col-12 col-md-6>
-
-
-        <div class="col-12 d-none d-lg-block">
-            <svg class="bd-placeholder-img" width="100%" height="500" xmlns="http://www.w3.org/2000/svg" role="img"
-                 aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
-                <title>Placeholder</title>
-
-                <rect width="100%" height="100%" fill="#55595c"/>
-                <text x="50%" y="50%" fill="#eceeef" dy=".3em">Background Image</text>
-                <text x="20%" y="50%" fill="#eceeef" dy=".3em">Slogan</text>
-                <text x="20%" y="60%" fill="#eceeef" dy=".3em">
-
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                </text>
-                <text x="20%" y="65%" fill="#eceeef" dy=".3em">
-
-                    Ut libero nisl, suscipit sit amet sem vitae, feugiat imperdiet tortor.
-
-                </text>
-
-                <text x="20%" y="70%" fill="#eceeef" dy=".3em">
-
-
-                    Duis vitae bibendum magna. Vestibulum a dui id nunc
-
-                </text>
-                <text x="20%" y="75%" fill="#eceeef" dy=".3em">
-
-                    Proin nisi dui, pretium non accumsan quis, hendrerit eget orci.
-                    Sed ornare purus malesuada, vestibulum libero placerat, bibendum tortor.
-                </text>
-                <text x="20%" y="80%" fill="#eceeef" dy=".3em">
-                    Etiam ut massa est. Aenean lorem magna, consequat in egestas et, fringilla sit amet mi.
-
-                </text>
-
-
-            </svg>
-        </div>
-
-    </div>
-
-</div> <!-- End title banner row-->
+<!-- Include banner -->
+<div id="banner"></div>
+<!-- end banner -->
 
 
 <div class="row pt-5"> <!-- Page title and summary -->
@@ -211,90 +169,9 @@
 <!-- End dynamic node registry content -->
 
 
-<div class="row d-none d-sm-block  "> <!-- Start pictures section row-->
-
-
-    <div class="album  py-5 bg-body-tertiary ">
-        <div class="  container  ">
-
-            <div class="row  row-cols-1 row-cols-sm-2 row-cols-md-3 g-3   ">
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-eVcfzGhVpYc-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-EpTN7eW3OZs-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-rXj2M7xtdB8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-7xF_CS4JC8c-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-xnrDoc_Hmm8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-</div> <!-- End  pictures section row-->
+<!-- Include pictures -->
+<div id="pictures"></div>
+<!-- end pictures -->
 
 
 <div class="row">

--- a/weaver.html
+++ b/weaver.html
@@ -11,6 +11,8 @@
             crossorigin="anonymous"></script>
     <script src="/js/load_menu.js"></script>
     <script src="/js/load_footer.js"></script>
+    <script src="/js/load_banner.js"></script>
+    <script src="/js/load_pictures.js"></script>
     <meta charset="UTF-8">
 
     <title>Title</title>
@@ -20,47 +22,9 @@
 <div id="menu"></div>
 <!-- end menu-->
 
-
-<div class="row"> <!-- Title banner row -->
-
-    <div col-12 col-md-6>
-
-
-        <div class="col-12 d-none d-lg-block">
-            <svg class="bd-placeholder-img" width="100%" height="500" xmlns="http://www.w3.org/2000/svg" role="img"
-                 aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
-                <title>Placeholder</title>
-
-                <rect width="100%" height="100%" fill="#55595c"/>
-                <text x="50%" y="50%" fill="#eceeef" dy=".3em">Background Image</text>
-                <text x="20%" y="50%" fill="#eceeef" dy=".3em">Slogan</text>
-                <text x="20%" y="60%" fill="#eceeef" dy=".3em">
-
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                </text>
-                <text x="20%" y="65%" fill="#eceeef" dy=".3em">
-                    Ut libero nisl, suscipit sit amet sem vitae, feugiat imperdiet tortor.
-                </text>
-
-                <text x="20%" y="70%" fill="#eceeef" dy=".3em">
-                    Duis vitae bibendum magna. Vestibulum a dui id nunc
-                </text>
-                <text x="20%" y="75%" fill="#eceeef" dy=".3em">
-                    Proin nisi dui, pretium non accumsan quis, hendrerit eget orci.
-                    Sed ornare purus malesuada, vestibulum libero placerat, bibendum tortor.
-                </text>
-                <text x="20%" y="80%" fill="#eceeef" dy=".3em">
-                    Etiam ut massa est. Aenean lorem magna, consequat in egestas et, fringilla sit amet mi.
-
-                </text>
-
-
-            </svg>
-        </div>
-
-    </div>
-
-</div> <!-- End title banner row-->
+<!-- Include banner -->
+<div id="banner"></div>
+<!-- end banner -->
 
 
 <div class="row pt-5"> <!-- Page title and summary -->
@@ -198,91 +162,9 @@
 <div id="accordionContentDisplay"></div>
 <!-- End dynamic node registry content -->
 
-
-<div class="row d-none d-sm-block  "> <!-- Start pictures section row-->
-
-
-    <div class="album  py-5 bg-body-tertiary ">
-        <div class="  container  ">
-
-            <div class="row  row-cols-1 row-cols-sm-2 row-cols-md-3 g-3   ">
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-eVcfzGhVpYc-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-EpTN7eW3OZs-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-rXj2M7xtdB8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-7xF_CS4JC8c-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-xnrDoc_Hmm8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-</div> <!-- End  pictures section row-->
+<!-- Include pictures -->
+<div id="pictures"></div>
+<!-- end pictures -->
 
 <!-- Start footer -->
 <div class="row">

--- a/wps.html
+++ b/wps.html
@@ -11,6 +11,8 @@
     <link href="/css/daccs-css.css" rel="stylesheet">
     <script src="/js/load_menu.js"></script>
     <script src="/js/load_footer.js"></script>
+    <script src="/js/load_banner.js"></script>
+    <script src="/js/load_pictures.js"></script>
 
     <meta charset="UTF-8">
     <title>Title</title>
@@ -21,43 +23,9 @@
 <!-- end menu-->
 
 
-<div class="row"> <!-- Title banner row -->
-
-    <div col-12 col-md-6>
-
-
-        <div class="col-12 d-none d-lg-block">
-            <svg class="bd-placeholder-img" width="100%" height="500" xmlns="http://www.w3.org/2000/svg" role="img"
-                 aria-label="Placeholder: Thumbnail" preserveAspectRatio="xMidYMid slice" focusable="false">
-                <title>Placeholder</title>
-
-                <rect width="100%" height="100%" fill="#55595c"/>
-                <text x="50%" y="50%" fill="#eceeef" dy=".3em">Background Image</text>
-                <text x="20%" y="50%" fill="#eceeef" dy=".3em">Slogan</text>
-                <text x="20%" y="60%" fill="#eceeef" dy=".3em">
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                </text>
-                <text x="20%" y="65%" fill="#eceeef" dy=".3em">
-                    Ut libero nisl, suscipit sit amet sem vitae, feugiat imperdiet tortor.
-                </text>
-
-                <text x="20%" y="70%" fill="#eceeef" dy=".3em">
-                    Duis vitae bibendum magna. Vestibulum a dui id nunc
-                </text>
-                <text x="20%" y="75%" fill="#eceeef" dy=".3em">
-                    Proin nisi dui, pretium non accumsan quis, hendrerit eget orci.
-                    Sed ornare purus malesuada, vestibulum libero placerat, bibendum tortor.
-                </text>
-                <text x="20%" y="80%" fill="#eceeef" dy=".3em">
-                    Etiam ut massa est. Aenean lorem magna, consequat in egestas et, fringilla sit amet mi.
-                </text>
-            </svg>
-        </div>
-
-    </div>
-
-</div> <!-- End title banner row-->
-
+<!-- Include banner -->
+<div id="banner"></div>
+<!-- end banner -->
 
 <div class="row pt-5"> <!-- Page title and summary -->
     <div class="col-4"></div>
@@ -260,90 +228,9 @@
 <!-- End dynamic node registry content -->
 
 
-<div class="row d-none d-sm-block  "> <!-- Start pictures section row-->
-
-
-    <div class="album  py-5 bg-body-tertiary ">
-        <div class="  container  ">
-
-            <div class="row  row-cols-1 row-cols-sm-2 row-cols-md-3 g-3   ">
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-eVcfzGhVpYc-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-EpTN7eW3OZs-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-rXj2M7xtdB8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-7xF_CS4JC8c-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <img src="images/usgs-xnrDoc_Hmm8-unsplash.jpg" width="100%" height="225"/>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false"><title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text>
-                        </svg>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-
-</div> <!-- End  pictures section row-->
+<!-- Include pictures -->
+<div id="pictures"></div>
+<!-- end pictures -->
 
 <div class="row">
 


### PR DESCRIPTION
The banner and pictures sections are copied over multiple files. It is easier to maintain them if they exist as a snippet that can be dynamically loaded by the pages that need them