### PR TITLE
Tools - updated tools.js and node-section-template.html

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -299,9 +299,7 @@ function buildNodeGroup(jsonTree, template, start, end) {
         nodeSectionContent = nodeSectionContent.replace("{{NODE_LINK_IMG_ID}}", nodeLinkImgID);
         nodeSectionContent = nodeSectionContent.replace("{{NODE_LOGO_ID}}", nodeLogoID);
         nodeSectionContent = nodeSectionContent.replace("{{NODE_DESCRIPTION_COLUMN_ID}}", nodeDescriptionColumnID);
-        nodeSectionContent = nodeSectionContent.replace("{{NODE_LINK_TEXT_ID}}", nodeLinkTextID);
         nodeSectionContent = nodeSectionContent.replace("{{NODE_NAME_ID}}", nodeNameID);
-        nodeSectionContent = nodeSectionContent.replace("{{NODE_LINK_DESC_ID}}", nodeLinkDescriptionID);
         nodeSectionContent = nodeSectionContent.replace("{{NODE_DESCRIPTION_ID}}", nodeDescriptionID);
         nodeSectionContent = nodeSectionContent.replaceAll("{{NODE_HREF}}", nodeURL);
         nodeSectionContent = nodeSectionContent.replace("{{NODE_LOGO_PATH}}", nodeIconURL);

--- a/templates/node-section-template.html
+++ b/templates/node-section-template.html
@@ -1,18 +1,14 @@
 <!-- NODE_CONTENT_ID content start -->
-<div class="d-flex align-items-start" id="{{NODE_CONTENT_ID}}">
+<div class="d-flex align-items-start position-relative" id="{{NODE_CONTENT_ID}}">
     <div class="logo-box col-3" id="{{NODE_LOGO_COLUMN_ID}} ">
-        <a id="{{NODE_LINK_IMG_ID}}" href="{{NODE_HREF}}"><img src="{{NODE_LOGO_PATH}}" class="img-fluid"
+        <a id="{{NODE_LINK_IMG_ID}}" class="stretched-link" href="{{NODE_HREF}}"><img src="{{NODE_LOGO_PATH}}" class="img-fluid"
                                                                id="{{NODE_LOGO_ID}}"/></a>
     </div>
     <div id="{{NODE_DESCRIPTION_COLUMN_ID}}" class="col-9">
-        <a class="href-text" id="{{NODE_LINK_TEXT_ID}}" href="{{NODE_HREF}}">
+
             <h2 id="{{NODE_NAME_ID}}">{{NODE_NAME}}</h2>
-        </a>
 
-        <a class="href-text" id="{{NODE_LINK_DESC_ID}}" href="{{NODE_HREF}}">
             <p id="{{NODE_DESCRIPTION_ID}}">{{NODE_DESCRIPTION}}</p>
-        </a>
-
 
     </div>
 </div>


### PR DESCRIPTION
- Added "stretched-link" and "position-relative" classes to the node section template.  This will allow the link in the node logo to be applied to the entire node section and allow it to be clickable.

- Removed lines from tools.js that would replace the node url into the NODE_LINK_TEXT_ID and NODE_LINK_DESC_ID constants as they are no longer needed.